### PR TITLE
feat(auth): 회원가입 시 사용자 중복 검증 로직 추가

### DIFF
--- a/auth-server/src/auth/auth.service.ts
+++ b/auth-server/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ export class AuthService {
     ) {}
 
     async register(dto: RequestRegisterDto): Promise<string> {
+        await this.usersService.exists(dto.username);
         const hashed: string = await bcrypt.hash(dto.password, 10);
         await this.usersService.create(dto.username, hashed, dto.roles);
         return "success";

--- a/auth-server/src/user/users.service.ts
+++ b/auth-server/src/user/users.service.ts
@@ -1,11 +1,17 @@
 import { Model } from "mongoose";
-import { Injectable } from "@nestjs/common";
+import { ConflictException, Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import {User, UserDocument } from "./schemas/user.schema";
 
 @Injectable()
 export class UsersService {
     constructor(@InjectModel(User.name) private readonly userModel: Model<UserDocument>) {}
+
+    async exists(username: string): Promise<void> {
+        if (await this.userModel.exists({ username }) !== null) {
+            throw new ConflictException('Already exists');
+        }
+    }
 
     async create(
         username: string,


### PR DESCRIPTION
- users.service.ts에 사용자명 중복 여부 검사 및 예외 처리 로직 구현
- auth.service.ts에서 회원가입 시 중복 사용자 검증 후 계정 생성하도록 변경
- 기존 회원가입 흐름에 ConflictException 예외 처리 추가