### PR TITLE
fix(rewards): 이벤트별 보상 조회 기능 개선 및 예외 처리 추가

### DIFF
--- a/event-server/src/rewards/reward.controller.ts
+++ b/event-server/src/rewards/reward.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post } from '@nestjs/common';
+import { Controller, Get, Post, Query } from '@nestjs/common';
 import { RewardService } from './reward.service';
 import { RequestCreateRewardDto } from './dto/request.create-reward.dto';
 
@@ -12,9 +12,10 @@ export class RewardController {
     }
 
     @Get("get-rewards")
-    findAll(data: { eventId?: string }) {
-        return data.eventId
-            ? this.rewardService.findByEvent(data.eventId)
+    findAll(@Query('eventId') eventId?: string ) {
+        return eventId
+            ? this.rewardService.findByEvent(eventId)
             : this.rewardService.findAll();
     }
+
 }

--- a/event-server/src/rewards/reward.service.ts
+++ b/event-server/src/rewards/reward.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Reward, RewardDocument } from './schemas/reward.schema';
@@ -11,14 +11,18 @@ export class RewardService {
     ) {}
 
     async create(createRewardDto: RequestCreateRewardDto): Promise<Reward> {
-        return this.rewardModel.create(createRewardDto);
+        return await this.rewardModel.create(createRewardDto);
     }
 
     async findAll(): Promise<Reward[]> {
-        return this.rewardModel.find().exec();
+        return await this.rewardModel.find().exec();
     }
 
-    async findByEvent(eventId: string): Promise<Reward[]> {
-        return this.rewardModel.find({ eventId }).exec();
+    async findByEvent(eventId: string): Promise<RewardDocument[]> {
+        const rewards = await this.rewardModel.find({ eventId }).exec();
+        if (rewards.length === 0) {
+            throw new NotFoundException("해당 이벤트의 보상을 찾을 수 없습니다.");
+        }
+        return rewards;
     }
 }


### PR DESCRIPTION
- reward.controller.ts: @Query 데코레이터를 사용해 eventId 쿼리 파라미터 수신 처리
- reward.service.ts: findByEvent 메서드에 보상 없을 시 NotFoundException 발생 로직 추가
- reward.service.ts: findAll 메서드에 명시적 async/await 구문 적용
- 이벤트 ID 기준 보상 조회 시 404 에러 응답 구현